### PR TITLE
automatic http body read, conn holder, timeout support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Pool
 
-Pool is a thread safe connection pool for net.Conn interface. It can be used to
-manage and reuse connections.
+Pool is a thread safe connection pool for any kinds of connections. It enforces blocking of the client requests when the pool is exhausted
 
 
 ## Install and Usage

--- a/adapters/pooled_http_client.go
+++ b/adapters/pooled_http_client.go
@@ -27,6 +27,10 @@ type PooledHttpClient struct {
 	OutstandingConns int32
 }
 
+// HttpResponseBody is an adapter for body present within http.Respose
+// it holds all of the data from the original body and presents the same
+// io.Reader interface to the outside world so that this body can be used
+// in the same way as the original
 type HttpResponseBody struct {
 	io.ReadCloser
 	body io.Reader

--- a/channel_test.go
+++ b/channel_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 	"strings"
-	
+
 	"golang.org/x/net/context"
 
 )
@@ -120,6 +120,25 @@ func TestPool_Get(t *testing.T) {
 	}
 	if !timedOut {
 		t.Errorf("Got a connection after pool was exhausted: %s", err)
+	}
+}
+
+func TestPool_PutTwiceNotAllowed(t *testing.T) {
+	p, err := NewChannelPool(2, factory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	conn1, err := p.Get()
+	_, err = p.Get()
+
+	p.Put(conn1)
+	// attempt to add the same conn twice
+	p.Put(conn1)
+
+	if p.Len() == 2 {
+		t.Errorf("put the same connection back to the pool twice")
 	}
 }
 

--- a/channel_test.go
+++ b/channel_test.go
@@ -5,8 +5,10 @@ import (
 	"sync"
 	"testing"
 	"time"
-
+	"strings"
+	
 	"golang.org/x/net/context"
+
 )
 
 var (
@@ -35,6 +37,24 @@ func TestPool_Get_Impl(t *testing.T) {
 	_, ok := connHolder.Conn.(GenericConn)
 	if !ok {
 		t.Errorf("Conn is not of type ConnectionHolder")
+	}
+}
+
+func TestChannelPool_GetWithTimeout(t *testing.T) {
+	pool, err := NewChannelPool(1, factory)
+	defer pool.Close()
+
+	_, err = pool.Get()
+	if err != nil {
+		t.Errorf("Get error: %s", err)
+	}
+
+	if pool.Len() != 0 {
+		t.Errorf("pool size is not exhausted")
+	}
+	_, err = pool.GetWithTimeout(100 * time.Millisecond)
+	if err == nil || !strings.HasPrefix(err.Error(), "timed out") {
+		t.Errorf("timeout error expected but not received")
 	}
 }
 

--- a/pool.go
+++ b/pool.go
@@ -3,12 +3,25 @@ package pool
 
 import (
 	"errors"
+	"time"
 )
 
 var (
 	// ErrClosed is the error resulting if the pool is closed via pool.Close().
-	ErrClosed = errors.New("pool is closed")
+	ErrClosed   = errors.New("pool is closed")
+	ErrTimedOut = errors.New("timed out waiting for connection")
 )
+
+type GenericConn interface{}
+
+type ConnectionHolder struct {
+	Conn  GenericConn
+	InUse bool
+}
+
+func NewConnectionHolder(conn GenericConn) *ConnectionHolder {
+	return &ConnectionHolder{Conn: conn}
+}
 
 // Pool interface describes a pool implementation. A pool should have maximum
 // capacity. An ideal pool is threadsafe and easy to use.
@@ -16,9 +29,11 @@ type Pool interface {
 	// Get returns a new connection from the pool. Closing the connections puts
 	// it back to the Pool. Closing it when the pool is destroyed or full will
 	// be counted as an error.
-	Get() (GenericConn, error)
+	Get() (*ConnectionHolder, error)
 
-	Put(GenericConn) error
+	GetWithTimeout(time.Duration) (*ConnectionHolder, error)
+
+	Put(*ConnectionHolder) error
 	// Close closes the pool and all its connections. After Close() the pool is
 	// no longer usable.
 	Close()


### PR DESCRIPTION
- Adding support in the pooled http client for automatically reading out the http body from the http response when we call a get or post
- Wrapping connections in a pool in a wrapper class which holds the InUse state and allows us to track whether a connection is being used or not.
- support for timeout
- more tests
